### PR TITLE
Specify Debian version

### DIFF
--- a/containers/service.Dockerfile
+++ b/containers/service.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:buster
 
 RUN apt-get update && \
   apt-get install -y libgmp-dev && \


### PR DESCRIPTION
We ran into an issue where the version of debian in the service
container was older than the version used to build the executable
resulting in an libc version skew. Specifying `buster` which is
compatible with the Docker image `haskell:8.8.3`