### PR TITLE
Use `LambdaCase` to simplify a case statement

### DIFF
--- a/src/Test/QuickCheck/Regex/PCRE/Types/Quantifiable.hs
+++ b/src/Test/QuickCheck/Regex/PCRE/Types/Quantifiable.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -73,10 +74,9 @@ instance Arbitrary Quantifiable where
     let shrunk :: [[CharacterClassCharacter]]
         shrunk = shrink (x : xs)
      in map
-          ( \l ->
-              case l of
-                [] -> CharacterClass x []
-                (a : as) -> CharacterClass a as
+          ( \case
+              [] -> CharacterClass x []
+              (a : as) -> CharacterClass a as
           )
           shrunk
   shrink (NegatedCharacterClass _ []) = []


### PR DESCRIPTION
As suggested by HLint