### PR TITLE
Force `lodash` to 4.17.19

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -5588,9 +5588,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.omit": {
       "version": "4.5.0",


### PR DESCRIPTION
Patch version update to resolve a potential security issue reported by
Github's Dependabot. Not used directly by the project, but is a
dependency of eslint and babel.

(Just making a notification go away, really).